### PR TITLE
fix: Update Cloud Build configuration to remove project ID from repos…

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -36,8 +36,8 @@ steps:
     args:
       - '-c'
       - |
-        if ! gcloud artifacts repositories describe ${_SERVICE_NAME} --location=${_LOCATION} --project=${PROJECT_ID}; then
-          gcloud artifacts repositories create ${_SERVICE_NAME} --repository-format=docker --location=${_LOCATION} --project=${PROJECT_ID};
+        if ! gcloud artifacts repositories describe ${_SERVICE_NAME} --location=${_LOCATION}; then
+          gcloud artifacts repositories create ${_SERVICE_NAME} --repository-format=docker --location=${_LOCATION};
         fi
   - name: 'gcr.io/cloud-builders/docker'
     id: Push Custom Builder
@@ -58,7 +58,7 @@ steps:
     args:
       [
         'build',
-        '${_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_SERVICE_NAME}/${_SERVICE_NAME}:latest',
+        '${_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_SERVICE_NAME}/${_SERVICE_NAME}:$COMMIT_SHA',
         '--builder',
         '${_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_SERVICE_NAME}/custom-builder:latest',
         '--run-image',
@@ -74,8 +74,7 @@ steps:
       - '-c'
       - |
         gcloud run deploy ${_SERVICE_NAME} \
-          # CAMBIO: Se despliega la imagen con la etiqueta 'latest'
-          --image ${_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_SERVICE_NAME}/${_SERVICE_NAME}:latest \
+          --image ${_LOCATION}-docker.pkg.dev/${PROJECT_ID}/${_SERVICE_NAME}/${_SERVICE_NAME}:$COMMIT_SHA \
           --region ${_LOCATION} \
           --allow-unauthenticated \
           --service-account default@${PROJECT_ID}.iam.gserviceaccount.com \


### PR DESCRIPTION
This pull request makes improvements to the deployment process in the `cloudbuild.yaml` file, focusing on better image versioning and simplifying repository creation commands. The main changes ensure that Docker images are tagged with a specific commit SHA instead of using the generic `latest` tag, which enhances traceability and reliability during deployments. Additionally, the artifact repository creation commands have been simplified by removing the project-specific flag.

**Deployment and image versioning improvements:**

* Docker images are now tagged with `$COMMIT_SHA` instead of `latest` in both the build and deploy steps, ensuring each deployment uses a uniquely identifiable image version. [[1]](diffhunk://#diff-0b4a5fc26445836e6672c426692297004cfaba21997343b63e6f58b946bd2a5cL61-R61) [[2]](diffhunk://#diff-0b4a5fc26445836e6672c426692297004cfaba21997343b63e6f58b946bd2a5cL77-R77)

**Repository creation command simplification:**

* The artifact repository creation and description commands no longer include the `--project=${PROJECT_ID}` flag, simplifying the configuration and relying on the default project context.